### PR TITLE
fix/font: :bug: 말줄임표 정렬 이슈 관련 css 수정 작업 (#20)

### DIFF
--- a/src/styles/Global.tsx
+++ b/src/styles/Global.tsx
@@ -12,19 +12,6 @@ const style = css`
     padding: 0;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    margin: 0;
-  }
-
-  li {
-    list-style: none;
-  }
-
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 100;
@@ -80,6 +67,19 @@ const style = css`
     padding: 0;
     border: none;
     background: none;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+  }
+
+  li {
+    list-style: none;
   }
 `
 

--- a/src/styles/Global.tsx
+++ b/src/styles/Global.tsx
@@ -12,12 +12,12 @@ const style = css`
     padding: 0;
   }
 
-  h1, 
-  h2, 
-  h3, 
-  h4, 
-  h5, 
-  h6{
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     margin: 0;
   }
 
@@ -30,42 +30,50 @@ const style = css`
     font-weight: 100;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-Thin.otf') format('opentype');
+    // exclude ellipsis (…, U+2026)
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 200;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-Light.otf') format('opentype');
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 300;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-DemiLight.otf') format('opentype');
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 400;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-Regular.otf') format('opentype');
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 500;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-Medium.otf') format('opentype');
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 600;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-Bold.otf') format('opentype');
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
   @font-face {
     font-family: 'NotoSansCJKkr';
     font-weight: 700;
     font-style: normal;
     src: url('/fonts/NotoSansCJKkr-Black.otf') format('opentype');
+    unicode-range: U+0-2025, U+2027-10FFFF;
   }
 
   button {


### PR DESCRIPTION
# 개요
말줄임표 정렬 이슈 관련 css 수정 작업
- vertically 가운데 정렬 된 말줄임표의 원인은 폰트(Noto Sans CJK)이기 때문에 해당 글자(U+2026)만 폰트 적용 제외


## 카테고리

- [x] Bug fix (not modifying existing features)
- [ ] New feature (not modifying existing features)
- [ ] Changing feature (modifying existing feature or fixing bug)
- [ ] Docs updated required

- [ ] Bug fix
- [ ] Add Feature
- [ ] Change Feature
- [ ] Chore

# 상세 내용
- ellipsis character '…' (U+2026) 폰트 적용 제외 (#20)