### PR TITLE
:bug: fix: 스테이징 환경 자동 배포 Action 버그

### DIFF
--- a/.github/workflows/deploy-staging-k8s.yaml
+++ b/.github/workflows/deploy-staging-k8s.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: cloudtype-github-actions/connect@v1
         with:
           token: ${{ secrets.STAGING_K8S_TOKEN }}
-          ghtoken: ${{ secrets.GITHUB_TOKEN }}
+          ghtoken: ${{ secrets.STAGING_GH_TOKEN }}
       - name: Deploy
         uses: cloudtype-github-actions/deploy@v1
         with:


### PR DESCRIPTION
# 개요
스테이징 환경 자동 배포 Action이 실행되는 중 토큰을 제대로 못잡는 오류가 있어 수정합니다.

## 카테고리

- [x] Bug fix (not modifying existing features)
- [ ] New feature (not modifying existing features)
- [ ] Changing feature (modifying existing feature or fixing bug)
- [ ] Docs updated required

- [x] Bug fix
- [ ] Add Feature
- [ ] Change Feature
- [ ] Chore

# 상세 내용
스테이징 환경 자동 배포 Action이 실행되는 중 GitHub의 이슈로 Repo Key를 못받아 오는 문제가 발생하여,
직접 SECRET에 Personal Access Token을 넣어서 배포하도록 수정했습니다.

머지전 PAT값을 STAGING_GH_TOKEN 시크릿에 등록해야 합니다.