### PR TITLE
Chore/eslint: prefer-default-export, require-default-props 옵션 off

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,12 @@
       {
         "endOfLine": "auto"
       }
-    ]
+    ],
+
+    // prefer default export 옵션 off
+    "import/prefer-default-export": "off",
+
+    // default props 정의 관련 옵션 off
+    "react/require-default-props": "off"
   }
 }


### PR DESCRIPTION
# 개요
`prefer-default-export`, `require-default-props` 옵션 off

## 카테고리

- [ ] Bug fix (not modifying existing features)
- [ ] New feature (not modifying existing features)
- [ ] Changing feature (modifying existing feature or fixing bug)
- [ ] Docs updated required
- [x] Chore

# 상세 내용
- 특이사항
  - `react/destructuring-assignment`
    - `({ propA }: IProps)` or `(props: IProps)`는 코딩 스타일의 문제이고, eslint 룰과는 관계 없기 떄문에 따로 룰 추가는 하지 않았습니다.