### PR TITLE
Chore/eslint: react/jsx-props-no-spreading 예외 룰 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,6 +53,19 @@
     "import/prefer-default-export": "off",
 
     // default props 정의 관련 옵션 off
-    "react/require-default-props": "off"
+    "react/require-default-props": "off",
+
+    // prop spreading 옵션 설정 (예외 이외에는 금지)
+    // 불가피한 경우 exceptions에 태그 추가하기
+    // ref: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md
+    "react/jsx-props-no-spreading": [
+      2,
+      {
+        "html": "enforce",
+        "custom": "enforce",
+        // _app.tsx 내 Component만 예외 처리
+        "exceptions": ["Component"]
+      }
+    ]
   }
 }


### PR DESCRIPTION
# 개요
`react/jsx-props-no-spreading` 에서, `_app.tsx` 내 `Component` 태그만 예외로 spreading prop 사용 가능하게끔 룰 추가하였습니다.

## 카테고리
- [x] Chore

# 상세 내용
