### PR TITLE
Fix/member-profile: dynamic routing 이슈

### DIFF
--- a/src/pages/member-profile/[memberName].tsx
+++ b/src/pages/member-profile/[memberName].tsx
@@ -4,10 +4,10 @@ import MemberProfileTopBanner from '@/components/MemberProfile/MemberProfileTopB
 import MemberProfileWakscord from '@/components/MemberProfile/MemberProfileWakscord'
 import MemberProfileYoutube from '@/components/MemberProfile/MemberProfileYoutube'
 import { css } from '@emotion/react'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from 'next'
+import { ParsedUrlQuery } from 'querystring'
 
-const whiteList = ['ine', 'jingburger', 'lilpa', 'jururu', 'gosegu', 'viichan']
+const memberList = ['ine', 'jingburger', 'lilpa', 'jururu', 'gosegu', 'viichan']
 
 const articleLayoutContainer = css`
   max-width: 1300px;
@@ -26,17 +26,30 @@ const splittedContainer = css`
   margin-bottom: 60px;
 `
 
-const MemberProfile = () => {
-  const router = useRouter()
-  const { memberName } = router.query
+export const getStaticPaths: GetStaticPaths = () => {
+  return {
+    paths: memberList.map((member) => {
+      return { params: { memberName: member } }
+    }),
+    fallback: false,
+  }
+}
 
-  // 예외 404 처리
-  useEffect(() => {
-    if (typeof memberName === 'string' && !whiteList.includes(memberName)) {
-      router.push('/404')
-    }
-  }, [memberName, router])
+interface MemberNameParams extends ParsedUrlQuery {
+  memberName: string
+}
+export const getStaticProps: GetStaticProps = (context) => {
+  const { memberName } = context.params as MemberNameParams
+  return {
+    props: {
+      memberName,
+    },
+  }
+}
 
+const MemberProfile = ({
+  memberName,
+}: InferGetStaticPropsType<typeof getStaticProps>) => {
   return (
     <article>
       {/* 배너 영역 */}


### PR DESCRIPTION
# 개요

- Closes #74 

## 카테고리
- [x] Bug fix

# 상세 내용
- getStaticPaths / Props를 활용하여 빌드타임에 멤버 별 라우트들에 해당하는 html파일을 생성하도록 코드 변경
- `fallback: false` 옵션을 통해 멤버명 이외의 route로 진입 시 404 페이지 반환
- 결과
(before)
![image](https://github.com/ISEGYE-Universe/frontend/assets/65759076/0de8e26b-1017-4385-a456-afd7ed909b1e)
(after)
![image](https://github.com/ISEGYE-Universe/frontend/assets/65759076/7e1ce82d-2e20-4304-b99b-2cdbd34f26f4)

