### PR TITLE
Fix/member-profile-calendar: 멤버 프로필 스케줄 > 달력 영역 highlight 스타일링 로직 개선

### DIFF
--- a/src/components/MemberProfile/MemberProfileCalendar.css.ts
+++ b/src/components/MemberProfile/MemberProfileCalendar.css.ts
@@ -9,7 +9,7 @@ export const calendarContentContainer = css`
   padding: 144px 62.5px 170px 8.5px;
 `
 
-export const calendarStyle = (dateList: string[]) => {
+export const calendarStyle = () => {
   return [
     TitleSmRegular,
     LineHeight,

--- a/src/components/MemberProfile/MemberProfileCalendar.css.ts
+++ b/src/components/MemberProfile/MemberProfileCalendar.css.ts
@@ -55,10 +55,10 @@ export const calendarStyle = (dateList: string[]) => {
               text-decoration: none;
             }
             &.react-calendar__month-view__weekdays__weekday--weekend {
-              abbr[aria-label='토요일'] {
+              abbr[aria-label='Saturday'] {
                 color: ${MemberProfileColor.scheduleTextBlue};
               }
-              abbr[aria-label='일요일'] {
+              abbr[aria-label='Sunday'] {
                 color: ${MemberProfileColor.scheduleTextRed};
               }
             }
@@ -77,20 +77,11 @@ export const calendarStyle = (dateList: string[]) => {
             color: ${MemberProfileColor.scheduleTextGrey};
             cursor: default;
 
-            // 스트리밍 진행된 날짜 하이라이트
-            ${dateList.map((date) => {
-              return `
-              abbr[aria-label='${new Date(date).toLocaleDateString('ko-KR', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}'] {
-                color: ${MemberProfileColor.scheduleTextWhite};
-                font-weight: 700;
-                cursor: pointer;
-              }  
-            `
-            })}
+            &.highlight {
+              color: ${MemberProfileColor.scheduleTextWhite};
+              font-weight: 700;
+              cursor: pointer;
+            }
           }
           .react-calendar__month-view__days__day--neighboringMonth {
             visibility: hidden;

--- a/src/components/MemberProfile/MemberProfileCalendar.tsx
+++ b/src/components/MemberProfile/MemberProfileCalendar.tsx
@@ -81,8 +81,6 @@ export const MemberProfileCalendar = ({
   return (
     <div css={calendarContentContainer}>
       <Calendar
-        // hydration error 해결
-        locale="kr"
         // year click event 제거
         minDetail="month"
         maxDetail="month"
@@ -128,6 +126,16 @@ export const MemberProfileCalendar = ({
           if (index !== -1) {
             scrollToHandler(index)
           }
+        }}
+        // 특정 날짜 강조 클래스
+        tileClassName={({ date }) => {
+          const index = calendarData.findIndex(
+            (el) => el.date === dateToStringDate(date),
+          )
+          if (index !== -1) {
+            return 'highlight'
+          }
+          return ''
         }}
       />
       <MemberProfileCalendarStreamList


### PR DESCRIPTION
# 개요
- `aria-label` 기반 스케줄 날짜 하이라이팅 로직 개선 (build 환경, 로컬 환경 간 locale 불일치 문제)

## 카테고리
- [x] Bug fix

## 상세 내용
- `tileClassName` prop을 활용하여 스케줄 있는 날짜에 `highlight` 클래스 부여하는 방식으로 변경