### PR TITLE
Fix/footer: 모달 비활성화 시에도 영역이 화면을 가리는 문제 해결

### DIFF
--- a/src/components/CommonLayout/Footer/CreatorModal.tsx
+++ b/src/components/CommonLayout/Footer/CreatorModal.tsx
@@ -71,7 +71,9 @@ export const CreatorModal = () => {
     top: 50%;
     transform: translate(-50%, -50%);
     z-index: 99;
-    transition: opacity 0.3s ease-out;
+    visibility: ${modalDefault ? 'visible' : 'hidden'};
+    // opacity 트랜지션을 위한 visibility 트랜지션 딜레이 부여
+    transition: opacity 0.3s ease-out ${!modalDefault && ', visibility 0s 0.3s'};
   `
   const LayerStyle = css`
     display: ${modalDefault ? 'block' : 'none'};


### PR DESCRIPTION
# 개요

## 카테고리
- [x] Bug fix

# 상세 내용
- 모달 비활성화 시 `opacity: 0;`만 적용되어 있어, 영역이 화면을 가리는 문제
- 해결: `visibility: hidden;` 속성 추가
  - opacity transition의 원활한 작동을 위해 모달 활성화 시에만 visibility transition-delay 부여