### PR TITLE
Feat/font: 폰트의 기본 line-height 지정

### DIFF
--- a/src/components/Albums/AlbumDetail.tsx
+++ b/src/components/Albums/AlbumDetail.tsx
@@ -3,7 +3,6 @@ import {
   AlignJustify,
   MainTitleRegular,
   TextMdBold,
-  LineHeight,
   TextMdRegular,
   TextMdLight,
 } from '@/styles/Font'
@@ -39,49 +38,41 @@ export const AlbumDetail = ({ album }: PropType) => {
   return (
     <div css={DivMarginSize}>
       <div>
-        <div css={[MainTitleRegular, LineHeight, AlbumTitle]}>
-          {info[album].title}
-        </div>
-        <div css={[DetailDesDiv, TextMdBold, LineHeight]}>
-          {info[album].description}
-        </div>
+        <div css={[MainTitleRegular, AlbumTitle]}>{info[album].title}</div>
+        <div css={[DetailDesDiv, TextMdBold]}>{info[album].description}</div>
       </div>
       <div css={AlbumInfoDiv}>
         <div css={SubInfo}>
-          <span css={[SubTitle, LineHeight, TextMdLight]}>발매일</span>
-          <span css={[SubColorMargin, TextMdRegular, LineHeight]}>
+          <span css={[SubTitle, TextMdLight]}>발매일</span>
+          <span css={[SubColorMargin, TextMdRegular]}>
             {info[album].release}
           </span>
         </div>
         <div css={SubInfo}>
-          <span css={[SubTitle, LineHeight, TextMdLight, AlignJustify]}>
-            장르
-          </span>
-          <span css={[SubColorMargin, TextMdRegular, LineHeight]}>
-            {info[album].genre}
-          </span>
+          <span css={[SubTitle, TextMdLight, AlignJustify]}>장르</span>
+          <span css={[SubColorMargin, TextMdRegular]}>{info[album].genre}</span>
         </div>
         <div css={SubInfo}>
-          <span css={[SubTitle, LineHeight, TextMdLight]}>발매사</span>
-          <span css={[SubColorMargin, TextMdRegular, LineHeight]}>
+          <span css={[SubTitle, TextMdLight]}>발매사</span>
+          <span css={[SubColorMargin, TextMdRegular]}>
             {info[album].publisher}
           </span>
         </div>
         <div css={SubInfo}>
-          <span css={[SubTitle, LineHeight, TextMdLight]}>기획사</span>
-          <span css={[SubColorMargin, TextMdRegular, LineHeight]}>
+          <span css={[SubTitle, TextMdLight]}>기획사</span>
+          <span css={[SubColorMargin, TextMdRegular]}>
             {info[album].agency}
           </span>
         </div>
         <div css={SubInfo}>
-          <span css={[SubTitle, LineHeight, TextMdLight]}>작사</span>
-          <span css={[SubColorMargin, TextMdRegular, LineHeight]}>
+          <span css={[SubTitle, TextMdLight]}>작사</span>
+          <span css={[SubColorMargin, TextMdRegular]}>
             {info[album].Lyrics}
           </span>
         </div>
         <div css={SubInfo}>
-          <span css={[SubTitle, LineHeight, TextMdLight]}>작곡</span>
-          <span css={[SubColorMargin, TextMdRegular, LineHeight]}>
+          <span css={[SubTitle, TextMdLight]}>작곡</span>
+          <span css={[SubColorMargin, TextMdRegular]}>
             {info[album].composition}
           </span>
         </div>

--- a/src/components/Chart/AlbumNewsCard.tsx
+++ b/src/components/Chart/AlbumNewsCard.tsx
@@ -1,5 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import { LineHeight, TextMdRegular } from '@/styles/Font'
+import { TextMdRegular } from '@/styles/Font'
 import { css } from '@emotion/react'
 
 interface AlbumNewsCardProps {
@@ -15,7 +15,7 @@ const albumCardContainer = css`
 export const AlbumNewsCard = ({ title }: AlbumNewsCardProps) => {
   return (
     <li css={albumCardContainer}>
-      <h3 css={[TextMdRegular, LineHeight]}>{title}</h3>
+      <h3 css={[TextMdRegular]}>{title}</h3>
     </li>
   )
 }

--- a/src/components/Chart/ArticleADBanner.tsx
+++ b/src/components/Chart/ArticleADBanner.tsx
@@ -1,10 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import {
-  LineHeight,
-  TextSmRegular,
-  TitleMdBold,
-  TitleSmRegular,
-} from '@/styles/Font'
+import { TextSmRegular, TitleMdBold, TitleSmRegular } from '@/styles/Font'
 import { css } from '@emotion/react'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -64,7 +59,7 @@ export const ArticleADBanner: React.FC<ArticleADBannerProps> = ({
             <h1
               css={[
                 TitleMdBold,
-                LineHeight,
+
                 css`
                   margin-bottom: 8px;
                 `,
@@ -72,10 +67,10 @@ export const ArticleADBanner: React.FC<ArticleADBannerProps> = ({
             >
               {title}
             </h1>
-            <h2 css={[TextSmRegular, LineHeight]}>{desc}</h2>
+            <h2 css={[TextSmRegular]}>{desc}</h2>
           </div>
           <div css={CTAContainerStyle}>
-            <span css={[TitleSmRegular, LineHeight]}>{CTAText}</span>
+            <span css={[TitleSmRegular]}>{CTAText}</span>
             <Image
               src="/images/icon/ad-right-chevron.svg"
               alt="right icon"

--- a/src/components/Chart/ChartMusicCard.tsx
+++ b/src/components/Chart/ChartMusicCard.tsx
@@ -1,10 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import {
-  CaptionMdLight,
-  LineHeight,
-  TextMdBold,
-  TextMdRegular,
-} from '@/styles/Font'
+import { CaptionMdLight, TextMdBold, TextMdRegular } from '@/styles/Font'
 import { css } from '@emotion/react'
 import Image from 'next/image'
 
@@ -92,9 +87,7 @@ export const ChartMusicCard = ({
       <div css={[flexRowContainer, flexAlignCenter, metadataContainer]}>
         {/* 순위, 등락 */}
         <div css={flexColContainer}>
-          <h3 css={[TextMdRegular, LineHeight, metaDataMarginBottom]}>
-            {position}
-          </h3>
+          <h3 css={[TextMdRegular, metaDataMarginBottom]}>{position}</h3>
           <div
             css={[
               flexRowContainer,
@@ -115,7 +108,7 @@ export const ChartMusicCard = ({
               css={[
                 CaptionMdLight,
                 changeFontStyle,
-                LineHeight,
+
                 css`
                   color: ${upDownColor};
                 `,
@@ -127,10 +120,8 @@ export const ChartMusicCard = ({
         </div>
         {/* 제목, 아티스트 */}
         <div css={[flexColContainer, flexAlignStart]}>
-          <h3 css={[TextMdBold, LineHeight, metaDataMarginBottom]}>{title}</h3>
-          <span css={[CaptionMdLight, artistFontStyle, LineHeight]}>
-            {artist}
-          </span>
+          <h3 css={[TextMdBold, metaDataMarginBottom]}>{title}</h3>
+          <span css={[CaptionMdLight, artistFontStyle]}>{artist}</span>
         </div>
       </div>
     </li>

--- a/src/components/Chart/HallOfFame.tsx
+++ b/src/components/Chart/HallOfFame.tsx
@@ -1,6 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
 import {
-  LineHeight,
   TextMdBold,
   TextMdRegular,
   TextSmRegular,
@@ -85,14 +84,12 @@ export const HallOfFame = ({
         <div css={[fullWidth, flexCol, spaceBetween]}>
           <div css={[flexCol, { gap: '10px' }]}>
             {/* metadata */}
-            <h2 css={[TitleSmRegular, LineHeight]}>{musicTitle}</h2>
-            <h3 css={[TextMdBold, LineHeight, { color: ChartColor.textGrey }]}>
-              {artist}
-            </h3>
+            <h2 css={[TitleSmRegular]}>{musicTitle}</h2>
+            <h3 css={[TextMdBold, { color: ChartColor.textGrey }]}>{artist}</h3>
             <span
               css={[
                 TextSmRegular,
-                LineHeight,
+
                 {
                   color: '#b0b0b0',
                   display: 'inline-block',
@@ -105,11 +102,11 @@ export const HallOfFame = ({
           {/* 하이라이트 메시지 list */}
           {/* 텍스트는 백엔드 소통 이후 변경 예정 */}
           <ul css={[flexCol, highlightMessageBox]}>
-            <li css={[TextMdRegular, LineHeight, highlightMessage]}>
+            <li css={[TextMdRegular, highlightMessage]}>
               <span css={[highlightText]}>11시간 50분</span>만에 100만 스트리밍
               달성 성공
             </li>
-            <li css={[TextMdRegular, LineHeight, highlightMessage]}>
+            <li css={[TextMdRegular, highlightMessage]}>
               24시간 <span css={[highlightText]}>1,825,900회</span> 스트리밍
               달성!
             </li>

--- a/src/components/Chart/HistoryCard.tsx
+++ b/src/components/Chart/HistoryCard.tsx
@@ -1,6 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
 import {
-  LineHeight,
   TextMdLight,
   TextSmLight,
   TextSmRegular,
@@ -60,25 +59,12 @@ export const HistoryCard = ({
         alt={`역대 기록 - ${title} 이미지`}
         css={{ marginBottom: '24px', objectFit: 'cover' }}
       />
-      <h3
-        css={[
-          categoryContainer,
-          TextSmRegular,
-          LineHeight,
-          { marginBottom: '10px' },
-        ]}
-      >
+      <h3 css={[categoryContainer, TextSmRegular, { marginBottom: '10px' }]}>
         {category}
       </h3>
-      <h2 css={[TitleSmRegular, LineHeight, { marginBottom: '16px' }]}>
-        {title}
-      </h2>
-      <span css={[TextMdLight, LineHeight, { marginBottom: '8px' }]}>
-        {desc}
-      </span>
-      <span css={[TextSmLight, LineHeight, { color: '#777' }]}>
-        {formattedDate}
-      </span>
+      <h2 css={[TitleSmRegular, { marginBottom: '16px' }]}>{title}</h2>
+      <span css={[TextMdLight, { marginBottom: '8px' }]}>{desc}</span>
+      <span css={[TextSmLight, { color: '#777' }]}>{formattedDate}</span>
     </div>
   )
 }

--- a/src/components/Chart/MelonInfo.tsx
+++ b/src/components/Chart/MelonInfo.tsx
@@ -1,4 +1,4 @@
-import { LineHeight, TextMdRegular, TitleSmRegular } from '@/styles/Font'
+import { TextMdRegular, TitleSmRegular } from '@/styles/Font'
 import { css } from '@emotion/react'
 import ChartColor from '@/styles/ChartColor'
 import { Title } from './Title'
@@ -48,8 +48,8 @@ export const MelonInfo = ({
             `,
           ]}
         >
-          <h3 css={[TextMdRegular, LineHeight]}>일간 감상자</h3>
-          <span css={[TitleSmRegular, LineHeight]}>
+          <h3 css={[TextMdRegular]}>일간 감상자</h3>
+          <span css={[TitleSmRegular]}>
             {/* comma 처리를 위해 toLocaleString() 이용 */}
             {dailyListenerNum.toLocaleString()}명
           </span>
@@ -62,8 +62,8 @@ export const MelonInfo = ({
             `,
           ]}
         >
-          <h3 css={[TextMdRegular, LineHeight]}>일간 차트</h3>
-          <span css={[TitleSmRegular, LineHeight]}>
+          <h3 css={[TextMdRegular]}>일간 차트</h3>
+          <span css={[TitleSmRegular]}>
             {dailyChartPosition.toLocaleString()}위
           </span>
         </div>

--- a/src/components/Chart/RoundedLinkButton.tsx
+++ b/src/components/Chart/RoundedLinkButton.tsx
@@ -1,5 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import { CaptionMdBold, LineHeight } from '@/styles/Font'
+import { CaptionMdBold } from '@/styles/Font'
 import { Interpolation, Theme, css } from '@emotion/react'
 import Link from 'next/link'
 
@@ -48,7 +48,7 @@ export const RoundedLinkButton = ({
             ${shadow && 'box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.50);'}
           `,
           fontStyle || CaptionMdBold,
-          LineHeight,
+
           customCss,
         ]}
       >

--- a/src/components/Chart/SubTitle.tsx
+++ b/src/components/Chart/SubTitle.tsx
@@ -1,5 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import { LineHeight, TextMdLight } from '@/styles/Font'
+import { TextMdLight } from '@/styles/Font'
 import { css } from '@emotion/react'
 
 interface SubTitleProps {
@@ -13,7 +13,7 @@ export const SubTitle = ({ children, mb, color }: SubTitleProps) => {
     <h2
       css={[
         TextMdLight,
-        LineHeight,
+
         css`
           ${mb && `margin-bottom: ${mb};`}
           color: ${color || ChartColor.textGrey};

--- a/src/components/Chart/Title.tsx
+++ b/src/components/Chart/Title.tsx
@@ -1,5 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import { LineHeight, TitleSmRegular } from '@/styles/Font'
+import { TitleSmRegular } from '@/styles/Font'
 import { css } from '@emotion/react'
 
 interface TitleProps {
@@ -13,7 +13,7 @@ export const Title = ({ children, mb, color }: TitleProps) => {
     <h2
       css={[
         TitleSmRegular,
-        LineHeight,
+
         css`
           ${mb && `margin-bottom: ${mb};`}
           color: ${color || ChartColor.textBlack};

--- a/src/components/Chart/Top100Chart.css.ts
+++ b/src/components/Chart/Top100Chart.css.ts
@@ -1,5 +1,5 @@
 import ChartColor from '@/styles/ChartColor'
-import { CaptionMdLight, LineHeight, TextSmBold } from '@/styles/Font'
+import { CaptionMdLight, TextSmBold } from '@/styles/Font'
 import { css } from '@emotion/react'
 
 const fontFamily = 'Noto Sans CJK KR'
@@ -83,7 +83,7 @@ export const tooltipContainer = (annotationOpen: boolean) => css`
 
 export const tooltipTimeText = [
   CaptionMdLight,
-  LineHeight,
+
   css`
     color: rgba(255, 255, 255, 0.5);
   `,
@@ -91,7 +91,6 @@ export const tooltipTimeText = [
 
 export const tooltipRankText = [
   TextSmBold,
-  LineHeight,
 
   css`
     color: ${ChartColor.textWhite};

--- a/src/components/Chart/Top100Section.tsx
+++ b/src/components/Chart/Top100Section.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import Image from 'next/image'
 import chartData from '@/data/chart.json'
 import ChartColor from '@/styles/ChartColor'
-import { LineHeight, TextSmLight } from '@/styles/Font'
+import { TextSmLight } from '@/styles/Font'
 import { RoundedLinkButton } from './RoundedLinkButton'
 import { Title } from './Title'
 import { Top100ChartSwitch } from './Top100ChartSwitch'
@@ -129,7 +129,7 @@ export const Top100Section = () => {
             <h4
               css={[
                 TextSmLight,
-                LineHeight,
+
                 css`
                   color: ${ChartColor.textLightGrey};
                 `,

--- a/src/components/Chart/WeeklyAward.tsx
+++ b/src/components/Chart/WeeklyAward.tsx
@@ -1,7 +1,6 @@
 import ChartColor from '@/styles/ChartColor'
 import {
   CaptionMdLight,
-  LineHeight,
   TextMdLight,
   TextMdRegular,
   TitleSmRegular,
@@ -95,8 +94,8 @@ export const WeeklyAward = ({
         ]}
       >
         {/* 투표, 남은시간 */}
-        <h3 css={[TitleSmRegular, LineHeight]}>투표 {position}위</h3>
-        <div css={[leftTimeStyle, CaptionMdLight, LineHeight]}>
+        <h3 css={[TitleSmRegular]}>투표 {position}위</h3>
+        <div css={[leftTimeStyle, CaptionMdLight]}>
           {/* 남은 시간 계산 로직으로 대체할 예정 */}
           {timeLeftResult}
         </div>
@@ -112,10 +111,8 @@ export const WeeklyAward = ({
           `,
         ]}
       >
-        <span css={[TextMdRegular, LineHeight]}>
-          {voteNum.toLocaleString()}표
-        </span>
-        <span css={[TextMdLight, LineHeight]}>({voteRatio}%)</span>
+        <span css={[TextMdRegular]}>{voteNum.toLocaleString()}표</span>
+        <span css={[TextMdLight]}>({voteRatio}%)</span>
       </div>
       {/* 득표 바 */}
       <div css={voteBarStyle}>

--- a/src/components/MemberProfile/MemberProfileCalendar.css.ts
+++ b/src/components/MemberProfile/MemberProfileCalendar.css.ts
@@ -1,4 +1,4 @@
-import { LineHeight, TitleSmRegular } from '@/styles/Font'
+import { TitleSmRegular } from '@/styles/Font'
 import { MemberProfileColor } from '@/styles/MemberProfileColor'
 import { css } from '@emotion/react'
 
@@ -11,7 +11,7 @@ export const calendarContentContainer = css`
 
 export const calendarStyle = [
   TitleSmRegular,
-  LineHeight,
+
   css`
     display: flex;
     flex-direction: column;

--- a/src/components/MemberProfile/MemberProfileCalendarStreamList.css.ts
+++ b/src/components/MemberProfile/MemberProfileCalendarStreamList.css.ts
@@ -1,4 +1,4 @@
-import { LineHeight, TitleSmRegular } from '@/styles/Font'
+import { TitleSmRegular } from '@/styles/Font'
 import { MemberProfileColor } from '@/styles/MemberProfileColor'
 import { css } from '@emotion/react'
 
@@ -14,7 +14,7 @@ export const streamListContainer = css`
 `
 export const streamListCarousel = [
   TitleSmRegular,
-  LineHeight,
+
   css`
     overflow: hidden;
     .embla__container {

--- a/src/components/MemberProfile/MemberProfileCoverSong.css.ts
+++ b/src/components/MemberProfile/MemberProfileCoverSong.css.ts
@@ -1,7 +1,6 @@
 import {
   CaptionMdLight,
   CaptionMdRegular,
-  LineHeight,
   TextMdBold,
   TextSmLight,
   TitleSmBold,
@@ -25,7 +24,7 @@ const alignCenter = css`
 
 export const memberProfileCoverSongMain = [
   flexCol,
-  LineHeight,
+
   css`
     position: relative;
     width: 770px;

--- a/src/components/MemberProfile/MemberProfileTitle.tsx
+++ b/src/components/MemberProfile/MemberProfileTitle.tsx
@@ -1,9 +1,4 @@
-import {
-  CaptionMdBold,
-  LineHeight,
-  TextMdRegular,
-  TitleLgRegular,
-} from '@/styles/Font'
+import { CaptionMdBold, TextMdRegular, TitleLgRegular } from '@/styles/Font'
 import { MemberProfileColor } from '@/styles/MemberProfileColor'
 import { css } from '@emotion/react'
 import memberProfileData from '@/data/member-profile.json'
@@ -31,7 +26,6 @@ const titleText = [
     color: ${MemberProfileColor.youtubeTitleTextGrey};
   `,
   TitleLgRegular,
-  LineHeight,
 ]
 const subTitleText = [
   css`
@@ -39,7 +33,6 @@ const subTitleText = [
     margin-bottom: 30.5px;
   `,
   TextMdRegular,
-  LineHeight,
 ]
 const ytLinkAnchor = css`
   color: ${MemberProfileColor.youtubeTitleTextGrey};
@@ -48,7 +41,7 @@ const ytLinkAnchor = css`
   align-items: center;
   gap: 4px;
 `
-const ytLinkText = [css``, CaptionMdBold, LineHeight]
+const ytLinkText = [css``, CaptionMdBold]
 
 export const MemberProfileTitle = ({
   title,

--- a/src/components/MemberProfile/MemberProfileTopBanner.css.ts
+++ b/src/components/MemberProfile/MemberProfileTopBanner.css.ts
@@ -2,7 +2,6 @@ import { css } from '@emotion/react'
 import { MemberProfileColor } from '@/styles/MemberProfileColor'
 import {
   CaptionMdBold,
-  LineHeight,
   TextSmLight,
   TextSmRegular,
   TitleSmBold,
@@ -71,20 +70,20 @@ export const profileImageStyle = css`
 export const memberNameText = [
   TitleSmBold,
   textWhite,
-  LineHeight,
+
   css`
     margin-bottom: 8px;
   `,
 ]
 export const groupNameText = [
   TextSmLight,
-  LineHeight,
+
   textWhite,
   css`
     margin-bottom: 16px;
   `,
 ]
-export const birthDateText = [TextSmRegular, LineHeight, textWhite]
+export const birthDateText = [TextSmRegular, textWhite]
 export const socialMediaContainer = [
   flexCol,
   css`
@@ -103,4 +102,4 @@ export const socialMediaIconStyle = css`
   vertical-align: bottom;
 `
 export const socialMediaLinkStyle = [flexRow, alignCenter]
-export const socialMediaTextStyle = [textWhite, LineHeight, CaptionMdBold]
+export const socialMediaTextStyle = [textWhite, CaptionMdBold]

--- a/src/components/MemberProfile/MemberProfileWakscord.css.ts
+++ b/src/components/MemberProfile/MemberProfileWakscord.css.ts
@@ -1,4 +1,4 @@
-import { LineHeight, TextMdRegular } from '@/styles/Font'
+import { TextMdRegular } from '@/styles/Font'
 import { MemberProfileColor } from '@/styles/MemberProfileColor'
 import { css } from '@emotion/react'
 
@@ -39,7 +39,7 @@ export const refreshIconButton = css`
 `
 export const refreshIconText = [
   TextMdRegular,
-  LineHeight,
+
   css`
     color: ${MemberProfileColor.wakscordTextGrey};
   `,

--- a/src/components/MemberProfile/MemberProfileYoutube.tsx
+++ b/src/components/MemberProfile/MemberProfileYoutube.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import memberProfileData from '@/data/member-profile.json'
 import Link from 'next/link'
 import Image from 'next/image'
-import { CaptionMdRegular, LineHeight } from '@/styles/Font'
+import { CaptionMdRegular } from '@/styles/Font'
 import { MemberProfileColor } from '@/styles/MemberProfileColor'
 import { MemberProfileTitle } from './MemberProfileTitle'
 
@@ -24,7 +24,6 @@ const youtubeListItemText = [
     color: ${MemberProfileColor.youtubeTitleTextGrey};
   `,
   CaptionMdRegular,
-  LineHeight,
 ]
 
 export const MemberProfileYoutube = ({

--- a/src/styles/Font.ts
+++ b/src/styles/Font.ts
@@ -72,130 +72,151 @@ export const MainTitleLight = css`
   ${fontFamily}
   ${fontWeightMedium}
   ${fontSizeMainTitle}
+  ${lineHeight}
 `
 export const MainTitleRegular = css`
   ${fontFamily}
   ${fontWeightBold}
   ${fontSizeMainTitle}
+  ${lineHeight}
 `
 export const MainTitleBold = css`
   ${fontFamily}
   ${fontWeightBlack}
   ${fontSizeMainTitle}
+  ${lineHeight}
 `
 // title_lg
 export const TitleLgLight = css`
   ${fontFamily}
   ${fontWeightDemiLight}
   ${fontSizeTitleLg}
+  ${lineHeight}
 `
 export const TitleLgRegular = css`
   ${fontFamily}
   ${fontWeightMedium}
   ${fontSizeTitleLg}
+  ${lineHeight}
 `
 export const TitleLgBold = css`
   ${fontFamily}
   ${fontWeightBlack}
   ${fontSizeTitleLg}
+  ${lineHeight}
 `
 // title_md
 export const TitleMdLight = css`
   ${fontFamily}
   ${fontWeightLight}
   ${fontSizeTitleMd}
+  ${lineHeight}
 `
 export const TitleMdRegular = css`
   ${fontFamily}
   ${fontWeightRegular}
   ${fontSizeTitleMd}
+  ${lineHeight}
 `
 export const TitleMdBold = css`
   ${fontFamily}
   ${fontWeightBold}
   ${fontSizeTitleMd}
+  ${lineHeight}
 `
 // title_sm
 export const TitleSmLight = css`
   ${fontFamily}
   ${fontWeightLight}
   ${fontSizeTitleSm}
+  ${lineHeight}
 `
 export const TitleSmRegular = css`
   ${fontFamily}
   ${fontWeightRegular}
   ${fontSizeTitleSm}
+  ${lineHeight}
 `
 export const TitleSmBold = css`
   ${fontFamily}
   ${fontWeightBold}
   ${fontSizeTitleSm}
+  ${lineHeight}
 `
 // text_md
 export const TextMdLight = css`
   ${fontFamily}
   ${fontWeightThin}
   ${fontSizeTextMd}
+  ${lineHeight}
 `
 export const TextMdRegular = css`
   ${fontFamily}
   ${fontWeightDemiLight}
   ${fontSizeTextMd}
+  ${lineHeight}
 `
 export const TextMdBold = css`
   ${fontFamily}
   ${fontWeightRegular}
   ${fontSizeTextMd}
+  ${lineHeight}
 `
 // text_sm
 export const TextSmLight = css`
   ${fontFamily}
   ${fontWeightThin}
   ${fontSizeTextSm}
+  ${lineHeight}
 `
 export const TextSmRegular = css`
   ${fontFamily}
   ${fontWeightDemiLight}
   ${fontSizeTextSm}
+  ${lineHeight}
 `
 export const TextSmBold = css`
   ${fontFamily}
   ${fontWeightRegular}
   ${fontSizeTextSm}
+  ${lineHeight}
 `
 // caption_md
 export const CaptionMdLight = css`
   ${fontFamily}
   ${fontWeightThin}
   ${fontSizeCaptionMd}
+  ${lineHeight}
 `
 export const CaptionMdRegular = css`
   ${fontFamily}
   ${fontWeightRegular}
   ${fontSizeCaptionMd}
+  ${lineHeight}
 `
 export const CaptionMdBold = css`
   ${fontFamily}
   ${fontWeightMedium}
   ${fontSizeCaptionMd}
+  ${lineHeight}
 `
 // caption_sm
 export const CaptionSmLight = css`
   ${fontFamily}
   ${fontWeightLight}
   ${fontSizeCaptionSm}
+  ${lineHeight}
 `
 export const CaptionSmRegular = css`
   ${fontFamily}
   ${fontWeightDemiLight}
   ${fontSizeCaptionSm}
+  ${lineHeight}
 `
 export const CaptionSmBold = css`
   ${fontFamily}
   ${fontWeightRegular}
   ${fontSizeCaptionSm}
-`
-export const LineHeight = css`
   ${lineHeight}
 `
 export const AlignJustify = css`


### PR DESCRIPTION
# 개요
여태껏 보니 피그마에서 웬만한 모든 폰트의 line-height값이 `110%`로 고정된 것으로 보이기 때문에 디폴트값로 지정
(매번 `LineHeight` 속성 넣어주는것도 슬슬 귀찮아서..)

## 카테고리
- [x] Change Feature

# 상세 내용
- `line-height: 110%`가 디폴트값으로 지정됩니다. 
> [!NOTE] 
> `line-height` 값이 110%가 아닌 예외의 경우에는 직접 지정해주는 것으로 합니다.
- 기존에 `LineHeight` css 적용된 부분의 코드를 모두 제거하였습니다.

